### PR TITLE
WORLDEDIT-3524: Fix copying of certain entities in 1.11

### DIFF
--- a/spigot_v1_11_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_11_R1.java
+++ b/spigot_v1_11_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_11_R1.java
@@ -134,7 +134,9 @@ public final class Spigot_v1_11_R1 implements BukkitImplAdapter {
      */
     @Nullable
     private static String getEntityId(Entity entity) {
-        return EntityTypes.b(entity);
+        MinecraftKey minecraftkey = EntityTypes.a(entity);
+
+        return minecraftkey == null ? null : minecraftkey.toString();
     }
 
     /**


### PR DESCRIPTION
The abovementioned ticket incorrectly suggests both that this is an issue unique to armor stands and is a Spigot issue. In fact this issue extends to all entities which changed IDs in the 1.11 update (armor stands and pig zombies used as test cases), and is caused by WorldEdit incorrectly using the old entity IDs to create internal snapshot representations, but the new IDs to paste them. This commit changes those IDs to the new IDs to allow clipboards created in 1.11 to be successfully pasted in 1.11(+). It does not however fix the (already existing) bug that older schematics will not have these changed entities pasted correctly. This is something that needs to be addressed separately, potentially at a level common to all platforms on which WorldEdit is supported.