### PR TITLE
Remove data version from adapters

### DIFF
--- a/spigot_v1_13_R2_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_13_R2_2.java
+++ b/spigot_v1_13_R2_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_13_R2_2.java
@@ -177,7 +177,7 @@ public final class Spigot_v1_13_R2_2 implements BukkitImplAdapter {
         // Spigot broke names mid-version, this is a test to see if it's before or after.
         new NBTTagString("test").asString();
 
-        new DataConverters_1_13_R2_2(getDataVersion(), this).build(ForkJoinPool.commonPool());
+        new DataConverters_1_13_R2_2(CraftMagicNumbers.INSTANCE.getDataVersion(), this).build(ForkJoinPool.commonPool());
 
         Watchdog watchdog;
         try {
@@ -196,11 +196,6 @@ public final class Spigot_v1_13_R2_2 implements BukkitImplAdapter {
             Class.forName("org.spigotmc.SpigotConfig");
             SpigotConfig.config.set("world-settings.worldeditregentempworld.verbose", false);
         } catch (ClassNotFoundException ignored) {}
-    }
-
-    @Override
-    public int getDataVersion() {
-        return CraftMagicNumbers.INSTANCE.getDataVersion();
     }
 
     @Override
@@ -507,7 +502,7 @@ public final class Spigot_v1_13_R2_2 implements BukkitImplAdapter {
             MinecraftServer server = originalWorld.getServer().getServer();
 
             WorldData newWorldData = new WorldData(originalWorld.worldData.a((NBTTagCompound) null),
-                    server.dataConverterManager, getDataVersion(), null);
+                    server.dataConverterManager, CraftMagicNumbers.INSTANCE.getDataVersion(), null);
             newWorldData.checkName("worldeditregentempworld");
             WorldNBTStorage saveHandler = new WorldNBTStorage(saveFolder,
                     originalWorld.getDataManager().getDirectory().getName(), server, server.dataConverterManager);

--- a/spigot_v1_14_R4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_14_R4.java
+++ b/spigot_v1_14_R4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_14_R4.java
@@ -179,7 +179,7 @@ public final class Spigot_v1_14_R4 implements BukkitImplAdapter {
         CraftServer.class.cast(Bukkit.getServer());
 
 
-        if (getDataVersion() != 1976) throw new UnsupportedClassVersionError("Not 1.14.4!");
+        if (CraftMagicNumbers.INSTANCE.getDataVersion() != 1976) throw new UnsupportedClassVersionError("Not 1.14.4!");
 
         // The list of tags on an NBTTagList
         nbtListTagListField = NBTTagList.class.getDeclaredField("list");
@@ -192,7 +192,7 @@ public final class Spigot_v1_14_R4 implements BukkitImplAdapter {
         nbtCreateTagMethod = NBTBase.class.getDeclaredMethod("createTag", byte.class);
         nbtCreateTagMethod.setAccessible(true);
 
-        new DataConverters_1_14_R4(getDataVersion(), this).build(ForkJoinPool.commonPool());
+        new DataConverters_1_14_R4(CraftMagicNumbers.INSTANCE.getDataVersion(), this).build(ForkJoinPool.commonPool());
 
         Watchdog watchdog;
         try {
@@ -211,11 +211,6 @@ public final class Spigot_v1_14_R4 implements BukkitImplAdapter {
             Class.forName("org.spigotmc.SpigotConfig");
             SpigotConfig.config.set("world-settings.worldeditregentempworld.verbose", false);
         } catch (ClassNotFoundException ignored) {}
-    }
-
-    @Override
-    public int getDataVersion() {
-        return CraftMagicNumbers.INSTANCE.getDataVersion();
     }
 
     @Override
@@ -560,7 +555,7 @@ public final class Spigot_v1_14_R4 implements BukkitImplAdapter {
             MinecraftServer server = originalWorld.getServer().getServer();
 
             WorldData newWorldData = new WorldData(originalWorld.worldData.a((NBTTagCompound) null),
-                    server.dataConverterManager, getDataVersion(), null);
+                    server.dataConverterManager, CraftMagicNumbers.INSTANCE.getDataVersion(), null);
             newWorldData.setName("worldeditregentempworld");
             WorldNBTStorage saveHandler = new WorldNBTStorage(saveFolder,
                     originalWorld.getDataManager().getDirectory().getName(), server, server.dataConverterManager);

--- a/spigot_v1_15_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_15_R2.java
+++ b/spigot_v1_15_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_15_R2.java
@@ -177,7 +177,7 @@ public final class Spigot_v1_15_R2 implements BukkitImplAdapter {
         CraftServer.class.cast(Bukkit.getServer());
 
 
-        if (getDataVersion() != 2230) throw new UnsupportedClassVersionError("Not 1.15.2!");
+        if (CraftMagicNumbers.INSTANCE.getDataVersion() != 2230) throw new UnsupportedClassVersionError("Not 1.15.2!");
 
         // The list of tags on an NBTTagList
         nbtListTagListField = NBTTagList.class.getDeclaredField("list");
@@ -186,7 +186,7 @@ public final class Spigot_v1_15_R2 implements BukkitImplAdapter {
         serverWorldsField = CraftServer.class.getDeclaredField("worlds");
         serverWorldsField.setAccessible(true);
 
-        new DataConverters_1_15_R2(getDataVersion(), this).build(ForkJoinPool.commonPool());
+        new DataConverters_1_15_R2(CraftMagicNumbers.INSTANCE.getDataVersion(), this).build(ForkJoinPool.commonPool());
 
         Watchdog watchdog;
         try {
@@ -205,11 +205,6 @@ public final class Spigot_v1_15_R2 implements BukkitImplAdapter {
             Class.forName("org.spigotmc.SpigotConfig");
             SpigotConfig.config.set("world-settings.worldeditregentempworld.verbose", false);
         } catch (ClassNotFoundException ignored) {}
-    }
-
-    @Override
-    public int getDataVersion() {
-        return CraftMagicNumbers.INSTANCE.getDataVersion();
     }
 
     @Override
@@ -550,7 +545,7 @@ public final class Spigot_v1_15_R2 implements BukkitImplAdapter {
             MinecraftServer server = originalWorld.getServer().getServer();
 
             WorldData newWorldData = new WorldData(originalWorld.worldData.a((NBTTagCompound) null),
-                    server.dataConverterManager, getDataVersion(), null);
+                    server.dataConverterManager, CraftMagicNumbers.INSTANCE.getDataVersion(), null);
             newWorldData.setName("worldeditregentempworld");
             WorldNBTStorage saveHandler = new WorldNBTStorage(saveFolder,
                     originalWorld.getDataManager().getDirectory().getName(), server, server.dataConverterManager);

--- a/spigot_v1_16_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_16_R1.java
+++ b/spigot_v1_16_R1/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_16_R1.java
@@ -144,7 +144,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World.Environment;
 import org.bukkit.block.data.BlockData;
-import org.bukkit.craftbukkit.libs.org.apache.commons.io.FileUtils;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld;
 import org.bukkit.craftbukkit.v1_16_R1.block.data.CraftBlockData;
@@ -159,7 +158,6 @@ import org.spigotmc.SpigotConfig;
 import org.spigotmc.WatchdogThread;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -202,7 +200,7 @@ public final class Spigot_v1_16_R1 implements BukkitImplAdapter {
         CraftServer.class.cast(Bukkit.getServer());
 
 
-        if (getDataVersion() != 2567) throw new UnsupportedClassVersionError("Not 1.16.1!");
+        if (CraftMagicNumbers.INSTANCE.getDataVersion() != 2567) throw new UnsupportedClassVersionError("Not 1.16.1!");
 
         // The list of tags on an NBTTagList
         nbtListTagListField = NBTTagList.class.getDeclaredField("list");
@@ -218,7 +216,7 @@ public final class Spigot_v1_16_R1 implements BukkitImplAdapter {
         chunkProviderExecutorField = ChunkProviderServer.class.getDeclaredField("serverThreadQueue");
         chunkProviderExecutorField.setAccessible(true);
 
-        new DataConverters_1_16_R1(getDataVersion(), this).build(ForkJoinPool.commonPool());
+        new DataConverters_1_16_R1(CraftMagicNumbers.INSTANCE.getDataVersion(), this).build(ForkJoinPool.commonPool());
 
         Watchdog watchdog;
         try {
@@ -237,11 +235,6 @@ public final class Spigot_v1_16_R1 implements BukkitImplAdapter {
             Class.forName("org.spigotmc.SpigotConfig");
             SpigotConfig.config.set("world-settings.worldeditregentempworld.verbose", false);
         } catch (ClassNotFoundException ignored) {}
-    }
-
-    @Override
-    public int getDataVersion() {
-        return CraftMagicNumbers.INSTANCE.getDataVersion();
     }
 
     @Override

--- a/spigot_v1_16_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_16_R2.java
+++ b/spigot_v1_16_R2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_16_R2.java
@@ -202,7 +202,8 @@ public final class Spigot_v1_16_R2 implements BukkitImplAdapter {
         CraftServer.class.cast(Bukkit.getServer());
 
 
-        if (getDataVersion() != 2578 && getDataVersion() != 2580) throw new UnsupportedClassVersionError("Not 1.16.2/.3!");
+        int dataVersion = CraftMagicNumbers.INSTANCE.getDataVersion();
+        if (dataVersion != 2578 && dataVersion != 2580) throw new UnsupportedClassVersionError("Not 1.16.2/.3!");
 
         // The list of tags on an NBTTagList
         nbtListTagListField = NBTTagList.class.getDeclaredField("list");
@@ -218,7 +219,7 @@ public final class Spigot_v1_16_R2 implements BukkitImplAdapter {
         chunkProviderExecutorField = ChunkProviderServer.class.getDeclaredField("serverThreadQueue");
         chunkProviderExecutorField.setAccessible(true);
 
-        new DataConverters_1_16_R2(getDataVersion(), this).build(ForkJoinPool.commonPool());
+        new DataConverters_1_16_R2(CraftMagicNumbers.INSTANCE.getDataVersion(), this).build(ForkJoinPool.commonPool());
 
         Watchdog watchdog;
         try {
@@ -237,11 +238,6 @@ public final class Spigot_v1_16_R2 implements BukkitImplAdapter {
             Class.forName("org.spigotmc.SpigotConfig");
             SpigotConfig.config.set("world-settings.worldeditregentempworld.verbose", false);
         } catch (ClassNotFoundException ignored) {}
-    }
-
-    @Override
-    public int getDataVersion() {
-        return CraftMagicNumbers.INSTANCE.getDataVersion();
     }
 
     @Override


### PR DESCRIPTION
Data versions aren't necessary in adapters, Bukkit provides them via API.