### PR TITLE
Update regen for recent spigot changes.

### DIFF
--- a/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_17_R1_2.java
+++ b/spigot_v1_17_R1_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/Spigot_v1_17_R1_2.java
@@ -160,14 +160,12 @@ import org.spigotmc.SpigotConfig;
 import org.spigotmc.WatchdogThread;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -195,9 +193,6 @@ public final class Spigot_v1_17_R1_2 implements BukkitImplAdapter {
     private final Field chunkProviderExecutorField;
     private final Watchdog watchdog;
 
-    private final Constructor<?> worldServerCtor;
-    private final boolean worldServerCtorUsesBiomeProvider;
-
     // ------------------------------------------------------------------------
     // Code that may break between versions of Minecraft
     // ------------------------------------------------------------------------
@@ -223,10 +218,6 @@ public final class Spigot_v1_17_R1_2 implements BukkitImplAdapter {
 
         chunkProviderExecutorField = ChunkProviderServer.class.getDeclaredField("h");
         chunkProviderExecutorField.setAccessible(true);
-
-        // hack for world gen changes, drop this once we stop supporting old builds
-        worldServerCtor = WorldServer.class.getDeclaredConstructors()[0];
-        worldServerCtorUsesBiomeProvider = worldServerCtor.getParameterCount() == 15;
 
         new DataConverters_1_17_R1_2(CraftMagicNumbers.INSTANCE.getDataVersion(), this).build(ForkJoinPool.commonPool());
 
@@ -620,7 +611,7 @@ public final class Spigot_v1_17_R1_2 implements BukkitImplAdapter {
                 originalSettings.e.g());
             WorldDataServer newWorldData = new WorldDataServer(newWorldSettings, newOpts, Lifecycle.stable());
 
-            List<Object> ctorArgs = new ArrayList<>(Arrays.asList(
+            WorldServer freshWorld = new WorldServer(
                 originalWorld.getMinecraftServer(),
                 originalWorld.getMinecraftServer().az,
                 session, newWorldData,
@@ -633,12 +624,9 @@ public final class Spigot_v1_17_R1_2 implements BukkitImplAdapter {
                 seed,
                 ImmutableList.of(),
                 false,
-                env, gen
-            ));
-            if (worldServerCtorUsesBiomeProvider) {
-                ctorArgs.add(bukkitWorld.getBiomeProvider());
-            }
-            WorldServer freshWorld = (WorldServer) worldServerCtor.newInstance(ctorArgs.toArray());
+                env, gen,
+                bukkitWorld.getBiomeProvider()
+            );
             try {
                 regenForWorld(region, extent, freshWorld, options);
             } finally {


### PR DESCRIPTION
The first commit will work on both old/new Spigot and current Paper, since they haven't merged upstream yet.

Second commit drops support for old ctor, which means we should announce breakage or at least make our bot tell people to update on
```
java.lang.NoSuchMethodError: 'org.bukkit.generator.BiomeProvider org.bukkit.World.getBiomeProvider()'
```